### PR TITLE
Fix sorting in project list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,6 @@ collections:
   projects:
     output: true
     permalink: /:collection/:name
-    sort_by: year
 
 plugins:
   - jemoji

--- a/_includes/project-list.html
+++ b/_includes/project-list.html
@@ -1,5 +1,5 @@
 <div class="row">
-  {% assign projects = site.projects | reverse %}
+  {% assign projects = site.projects | sort: "year" | reverse %}
   {% for project in projects %}
     {% assign name = project.url | remove: '/projects/' %}
     {% assign image = site.static_files | where: "image", true | where_exp: "item", "item.path contains name" | first %}

--- a/_includes/project-list.html
+++ b/_includes/project-list.html
@@ -1,13 +1,18 @@
 <div class="row">
-  {% assign projects = site.projects | sort: "year" | reverse %}
-  {% for project in projects %}
-    {% assign name = project.url | remove: '/projects/' %}
-    {% assign image = site.static_files | where: "image", true | where_exp: "item", "item.path contains name" | first %}
-    <article class="col-{{ include.col }} col-{{ include.col | times: 2 }}-xsmall work-item">
-      <a href="{{ project.url }}" class="image fit thumb"><img src="{{ image.path }}" alt="{{ project.title }}" /></a>
-      <h3>{{ project.title }}</h3>
-      <p>{{ project.platform }} | {{ project.year }}</p>
-      <p>{{ project.excerpt }}</p>
-    </article>
+  <!-- Group projects by years -->
+  {% assign project_years = site.projects | group_by: "year" | sort: "name" | reverse %}
+  {% for year in project_years %}
+    <!-- Sort projects of some year by month -->
+    {% assign sorted_projects = year.items | sort: "month" | reverse %}
+    {% for project in sorted_projects %}
+      {% assign name = project.url | remove: '/projects/' %}
+      {% assign image = site.static_files | where: "image", true | where_exp: "item", "item.path contains name" | first %}
+      <article class="col-{{ include.col }} col-{{ include.col | times: 2 }}-xsmall work-item">
+        <a href="{{ project.url }}" class="image fit thumb"><img src="{{ image.path }}" alt="{{ project.title }}" /></a>
+        <h3>{{ project.title }}</h3>
+        <p>{{ project.platform }} | {{ project.year }}</p>
+        <p>{{ project.excerpt }}</p>
+      </article>
+    {% endfor %}
   {% endfor %}
 </div>

--- a/_projects/interpreter.md
+++ b/_projects/interpreter.md
@@ -1,6 +1,7 @@
 ---
 title: Post–Turing Machine Command Interpreter
 year: 2018
+month: 05
 platform: Windows
 tool: VB.NET & Windows Forms
 file_name: Interpreter.zip

--- a/_projects/matrix.md
+++ b/_projects/matrix.md
@@ -1,6 +1,7 @@
 ---
 title: Matrix Processing Program
 year: 2018
+month: 12
 platform: Windows
 tool: Microsoft Visual C++
 file_name: MatrixProcessingProgram.zip


### PR DESCRIPTION
It seems like GitHub Pages doesn't support `sort_by` collection property in `_config.yml`.
- Remove sorting from configuration to include
- Add extra sorting by month